### PR TITLE
packages.jsonにbuildスクリプトを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write \"**/*.{js,ts,vue,scss,html,md,json}\" --ignore-path .gitignore",
     "test": "echo \"No test specified\" && exit 0",
     "emulators": "firebase emulators:start --import=./export",
-    "watch:functions": "yarn --cwd ./functions tsc -w"
+    "watch:functions": "yarn --cwd ./functions tsc -w",
+    "build": "quasar build"
   },
   "dependencies": {
     "@quasar/extras": "^1.0.0",


### PR DESCRIPTION
firebase.jsonに`npm --prefix \"$RESOURCE_DIR\" run build`の記述がありますが、packages.jsonにbuildスクリプトが未定義だったので追加します
